### PR TITLE
Add XRay upload option and adjust JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Set the following environment variables before running the script:
 - `CLIENT_ID`
 - `CLIENT_SECRET`
 - `AUTH_URL`
-- `XRAY_IMPORT_URL` *(not used yet)*
+- `XRAY_IMPORT_URL`
 - `PATH_EXCEL` – directory containing the Excel files.
 - `PATH_JSON` – directory where the JSON files will be generated.
 
@@ -36,3 +36,4 @@ python excel_to_xray_json.py
 ```
 
 Follow the menu prompts to provide the project key, feature number and Excel file name.
+After generating the JSON file, the application will offer the option to send it directly to XRay using the `XRAY_IMPORT_URL` endpoint.


### PR DESCRIPTION
## Summary
- output the generated JSON as a list of tests
- add optional sending of the JSON to XRay via `send_json_to_xray`
- document use of `XRAY_IMPORT_URL` and new sending feature

## Testing
- `python -m py_compile excel_to_xray_json.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68507aa3eff48320ac03c49e9d797bbe